### PR TITLE
Fix windows build

### DIFF
--- a/cpan/MANIFEST
+++ b/cpan/MANIFEST
@@ -42,6 +42,7 @@ engine/LOG_DATA
 engine/README
 engine/SHARED
 engine/STATIC
+engine/cf/write_makefile.pl
 engine/read_only/AUTHORS
 engine/read_only/COPYING
 engine/read_only/COPYING.LESSER

--- a/cpan/Makefile.PL
+++ b/cpan/Makefile.PL
@@ -558,7 +558,7 @@ INLINEHOOK
 
 } ## end if ($use_perl_autoconf)
 
-{
+else {
     my $shell            = $Config{sh};
     my $configure_script = 'configure';
     if ($verbose) {

--- a/cpan/Makefile.PL
+++ b/cpan/Makefile.PL
@@ -403,7 +403,7 @@ WriteMakefile(
     NO_META  => 1,
     MAN1PODS => \%pod_files,
     LICENSE  => 'lgpl3',
-    MYEXTLIB => 'xs/R3.o xs/libmarpa$(LIB_EXT)',
+    MYEXTLIB => 'xs/R3$(OBJ_EXT) xs/libmarpa$(LIB_EXT)',
 
     test => { RECURSIVE_TEST_FILES => 1 }
 
@@ -607,7 +607,7 @@ engine/perl_ac_build/.libs/libmarpa$(LIB_EXT): engine/read_only/stamp-h1
 	$(MKPATH) engine/perl_ac_build/.libs
 	cp engine/perl_ac_build/libmarpa$(LIB_EXT) engine/perl_ac_build/.libs
 
-xs/R3.o: xs/libmarpa$(LIB_EXT) \
+xs/R3$(OBJ_EXT): xs/libmarpa$(LIB_EXT) \
     xs/marpa.h \
     xs/marpa_codes.h \
     xs/general_pattern.xsh \

--- a/cpan/Makefile.PL
+++ b/cpan/Makefile.PL
@@ -603,7 +603,9 @@ engine/gnu_ac_build/.libs/libmarpa$(LIB_EXT): engine/read_only/stamp-h1
 	cd engine/gnu_ac_build && $(MAKE)
 
 engine/perl_ac_build/.libs/libmarpa$(LIB_EXT): engine/read_only/stamp-h1
-	cd engine/perl_ac_build && $(MAKE)
+	cd engine/perl_ac_build && $(PERLRUN) Makefile.PL && $(MAKE)
+	$(MKPATH) engine/perl_ac_build/.libs
+	cp engine/perl_ac_build/libmarpa$(LIB_EXT) engine/perl_ac_build/.libs
 
 xs/R3.o: xs/libmarpa$(LIB_EXT) \
     xs/marpa.h \

--- a/cpan/xs/Makefile.PL
+++ b/cpan/xs/Makefile.PL
@@ -60,6 +60,10 @@ all :: R3$(OBJ_EXT)
 config ::
 	$(NOECHO) $(NOOP)
 
+# test is SKIP’ped, so this avoids nmake’s “don’t know how to make test” complaints
+test ::
+	$(NOECHO) $(NOOP)
+
 ';
     return $r;
 }

--- a/cpan/xs/Makefile.PL
+++ b/cpan/xs/Makefile.PL
@@ -54,7 +54,7 @@ WriteMakefile(
 
 sub MY::top_targets {
     my $r = '
-all :: R3.o
+all :: R3$(OBJ_EXT)
 	$(NOECHO) $(NOOP)
 
 config ::


### PR DESCRIPTION
this fixes `perl Makefile.PL & nmake test` under windows without breaking `make releng` under cygwin
