### PR TITLE
cross-platform $(TOUCH) with $(RM_RF) and $(ECHO)

### DIFF
--- a/cpan/Makefile.PL
+++ b/cpan/Makefile.PL
@@ -476,7 +476,8 @@ END_OF_POSTAMBLE_PIECE
     push @postamble_pieces, sprintf <<'END_OF_POSTAMBLE_PIECE',
 engine/perl_ac_build/stamp-h1: engine/perl_ac_build/Makefile
 	%s
-	$(TOUCH) engine/perl_ac_build/stamp-h1
+	$(RM_RF) engine/perl_ac_build/stamp-h1
+	$(ECHO) stamp-h1 > engine/perl_ac_build/stamp-h1
 END_OF_POSTAMBLE_PIECE
 	$self->cd(File::Spec->catdir(qw(engine perl_ac_build)), '$(MAKE)');
 


### PR DESCRIPTION
This is a follow up to https://github.com/jeffreykegler/Marpa--R3/pull/7 -- looks like `rm -rf` followed by `echo` is the only way that worked for me under windows and xp and windows7 setup I've restored to test this issue.

I tried http://superuser.com/a/764721 and, while not requiring `rf -rf`, it failed to produce `stamp-h1` with the correct timestamp, in fact it left it untouched.
