### PR TITLE
fix unresolved symbol _PL_memory_wrap under windows7

### DIFF
--- a/cpan/xs/Makefile.PL
+++ b/cpan/xs/Makefile.PL
@@ -31,7 +31,7 @@ $VERSION = eval $VERSION;
 ## use critic
 
 my $define = q{};
-$define .= ' -DWIN32 -DPERL_STATIC_SYMS' if ($^O eq 'MSWin32');
+$define .= ' -DWIN32' if ($^O eq 'MSWin32');
 
 my @c_files = <*.c>;
 my $o_files = join q{ }, @c_files;


### PR DESCRIPTION
this fixes windows7 build for me with perl 5.22.1 and msvc 2010
