### PR TITLE
Fix windows build

### DIFF
--- a/cpan/Makefile.PL
+++ b/cpan/Makefile.PL
@@ -419,19 +419,19 @@ xs/R3$(OBJ_EXT): xs/libmarpa$(LIB_EXT) \
     xs/marpa_slifop.h
 
 xs/general_pattern.xsh: xs/gp_generate.pl
-	perl xs/gp_generate.pl xs/general_pattern.xsh
+	$(RUNPERL) xs/gp_generate.pl xs/general_pattern.xsh
 
 xs/marpa_slifop.h: xs/create_ops.pl
-	perl xs/create_ops.pl > xs/marpa_slifop.h
+	$(RUNPERL) xs/create_ops.pl > xs/marpa_slifop.h
 
 xs/marpa.h: $(LIBMARPA_BUILD_DIR)/marpa.h
-	cp $? $@
+	$(CP) $? $@
 
 xs/marpa_codes.h: $(LIBMARPA_BUILD_DIR)/marpa_codes.h
-	cp $? $@
+	$(CP) $? $@
 
 xs/libmarpa$(LIB_EXT): $(LIBMARPA_BUILD_DIR)/stamp-h1
-	cp $(LIBMARPA_IN_BUILD_DIR) $@
+	$(CP) $(LIBMARPA_IN_BUILD_DIR) $@
 
 END_OF_POSTAMBLE_PIECE
 

--- a/cpan/engine/cf/INSTALL.SKIP
+++ b/cpan/engine/cf/INSTALL.SKIP
@@ -1,3 +1,6 @@
 # this INSTALL.SKIP is for the copy of the libmarpa code
 # file names must be cpan-directory relative
 ^engine/read_only/stamp-h1$
+# ExtUtils::Install uses system-specific paths
+# so this will skip the file under Windows
+^engine\\read_only\\stamp-h1$


### PR DESCRIPTION
This fixes TOUCH issue mentioned in #8, which will thus be closed, and permission issues with copying `marpa.h` to `xs` dir.

Builds under Windows XP. Under Windows 7, goes to linking and fails as specified in #9 
