### PR TITLE
touch up windows build logic

### DIFF
--- a/cpan/lua/Makefile.PL
+++ b/cpan/lua/Makefile.PL
@@ -72,11 +72,11 @@ marpa_lua$(LIB_EXT): one$(OBJ_EXT)
 	$(CHMOD) $(PERM_RWX) $@
 
 lua: one.c
-	$(CC) -Fo $@ $(PASTHRU_INC) $(INC) $(CCFLAGS) $(OPTIMIZE) \
+	$(CC) -Fe$@ $(PASTHRU_INC) $(INC) $(CCFLAGS) $(OPTIMIZE) \
 	  $(PASTHRU_DEFINE) $(DEFINE) -DMAKE_LUA one.c
 
 luac: one.c
-	$(CC) -Fo $@ $(PASTHRU_INC) $(INC) $(CCFLAGS) $(OPTIMIZE) \
+	$(CC) -Fe$@ $(PASTHRU_INC) $(INC) $(CCFLAGS) $(OPTIMIZE) \
 	  $(PASTHRU_DEFINE) $(DEFINE) -DMAKE_LUAC one.c
 
 };


### PR DESCRIPTION
2 nits: (1) change Fo (object file name) to Fe (executable name) which is close to gcc's -o in this context and (2) remove whitespace after that option before the name.
