### PR TITLE
Fix build under threaded perls and windows

### DIFF
--- a/cpan/Makefile.PL
+++ b/cpan/Makefile.PL
@@ -361,7 +361,7 @@ WriteMakefile(
     CONFIGURE_REQUIRES => \%configure_requires,
     PM                 => \%pm_files,
     MIN_PERL_VERSION => '5.10.1',
-    DIR => [qw(engine xs)],
+    DIR => [qw(engine lua xs)],
     META_ADD => {
         no_index => {
             directory => [

--- a/cpan/xs/R3.xs
+++ b/cpan/xs/R3.xs
@@ -2316,6 +2316,7 @@ static lua_State *marpa_L = NULL;
 static SV*
 coerce_to_sv (lua_State * L, int idx)
 {
+  dTHX;
   SV *result;
   const int type = marpa_lua_type (L, idx);
 
@@ -2382,6 +2383,7 @@ coerce_to_sv (lua_State * L, int idx)
 static void
 push_val (lua_State * L, SV * val)
 {
+  dTHX;
   if (SvTYPE (val) == SVt_NULL)
     {
       // warn("%s %d\n", __FILE__, __LINE__);
@@ -2479,6 +2481,7 @@ static void marpa_sv_sv_noinc (lua_State* L, SV* sv) {
     (marpa_sv_sv_noinc((L), (sv)), SvREFCNT_inc_simple_void_NN (sv))
 
 static int marpa_sv_nil (lua_State* L) {
+    dTHX;
     /* [] */
     marpa_sv_sv_noinc( L, newSV(0) );
     /* [sv_userdata] */
@@ -2486,6 +2489,7 @@ static int marpa_sv_nil (lua_State* L) {
 }
 
 static int marpa_sv_finalize_meth (lua_State* L) {
+    dTHX;
     SV** p_sv = (SV**)marpa_luaL_checkudata(L, 1, MT_NAME_SV);
     SV* sv = *p_sv;
     // warn("decrementing ud %p, SV %p, %s %d\n", p_sv, sv, __FILE__, __LINE__);
@@ -2523,6 +2527,7 @@ static int marpa_sv_add_meth (lua_State* L) {
  * Will return 0, if there is no SV at that index.
  */
 static SV** marpa_av_fetch(lua_State* L, SV* table, lua_Integer key) {
+     dTHX;
      AV* av;
      SV* sv;
      if ( !SvROK(table) ) {
@@ -2553,6 +2558,7 @@ static int marpa_av_fetch_meth(lua_State* L) {
 }
 
 static void marpa_av_store(lua_State* L, SV* table, lua_Integer key, SV*value) {
+     dTHX;
      AV* av;
      if ( !SvROK(table) ) {
         croak ("Attempt to index an SV which is not ref");

--- a/cpan/xs/R3.xs
+++ b/cpan/xs/R3.xs
@@ -2503,8 +2503,9 @@ static int marpa_xlua_tonumber (lua_State* L, int idx, int* pisnum) {
     dTHX;
     void* ud;
     int pisnum2;
+    int n;
     if (pisnum) *pisnum = 1;
-    int n = marpa_lua_tonumberx(L, idx, &pisnum2);
+    n = marpa_lua_tonumberx(L, idx, &pisnum2);
     if (pisnum2) return n;
     ud = marpa_luaL_testudata(L, idx, MT_NAME_SV);
     if (!ud) {


### PR DESCRIPTION
Commits 86ac5ff and d8b57e9 fix compile and build under windows, accordingly, without breaking `make releng` under cygwin.

msvc produced a bunch of nits under windows, see below, IMHO they can wait until the code is finalized unless you say otherwise:

```
R3.xs(2508) : warning C4244: '=' : conversion from 'lua_Number' to 'int', possible loss of data
R3.xs(2515) : warning C4244: 'return' : conversion from 'NV' to 'int', possible loss of data
R3.xs(2541) : warning C4244: 'function' : conversion from 'lua_Integer' to 'int', possible loss of data
R3.xs(2533) : warning C4101: 'sv' : unreferenced local variable
R3.xs(2571) : warning C4244: 'function' : conversion from 'lua_Integer' to 'int', possible loss of data
R3.xs(2616) : warning C4244: 'function' : conversion from 'lua_Integer' to 'int', possible loss of data
R3.xs(7038) : warning C4101: 'function_ref' : unreferenced local variable
```
