### PR TITLE
revert var type change

### DIFF
--- a/cpan/xs/R3.xs
+++ b/cpan/xs/R3.xs
@@ -7426,7 +7426,7 @@ PPCODE:
 void
 char_register( slr, codepoint, ... )
     Scanless_R *slr;
-     int codepoint;
+    UV codepoint;
 PPCODE:
 {
   /* OP Count is args less two, then plus two for codepoint and length fields */


### PR DESCRIPTION
without this, `advent.t` doesn't exit (takes forever).
