### PR TITLE
use EU::MM cp command instead of standalone cp utility

### DIFF
--- a/cpan/engine/Makefile.PL
+++ b/cpan/engine/Makefile.PL
@@ -96,7 +96,7 @@ END_OF_POSTAMBLE_PIECE
 perl_ac_build/Makefile.PL: read_only/stamp-h1 cf/perl_ac_makefile.PL
 	$(RM_RF) perl_ac_build
 	$(LIBMARPA_INSTALL) read_only perl_ac_build
-	cp cf/perl_ac_makefile.PL perl_ac_build/Makefile.PL
+	$(CP) cf/perl_ac_makefile.PL perl_ac_build/Makefile.PL
 END_OF_POSTAMBLE_PIECE
 
 


### PR DESCRIPTION
This fixes the build under windows without cygwin, where standalone `cp` utility isn't available.
