### PR TITLE
fix #45: provide cpan/engine/read_only.time-stamp

### DIFF
--- a/cpan/engine/Makefile.PL
+++ b/cpan/engine/Makefile.PL
@@ -92,6 +92,11 @@ undef &MY::postamble; # suppress warning
       );
 
     push @postamble_pieces, <<'END_OF_POSTAMBLE_PIECE';
+read_only.time-stamp:
+	date > $@
+END_OF_POSTAMBLE_PIECE
+
+    push @postamble_pieces, <<'END_OF_POSTAMBLE_PIECE';
 gnu_ac_build.time-stamp: read_only.time-stamp
 	$(RM_RF) gnu_ac_build
 	$(LIBMARPA_INSTALL) read_only gnu_ac_build


### PR DESCRIPTION
The build process requires this files, but it is not checked into the repository. Therefore, the Makefile will generate that file iff required.

I am not sure what the time-stamp file is supposed to do. If the file's date content is in some way important, it should be committed instead.

Fixes issue #45.