### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: perl
+perl:
+  - "5.26"
+  - "5.24"
+  - "5.24-shrplib"  # at least one perl with threading support
+  - "5.10"  # minimum supported version
+
+# install prerequisites
+install:
+  # for debugging, output available perls
+  - perlbrew list
+  # install dependencies without testing, for speed
+  - (cd cpan/ && cpanm --installdeps --quiet --notest .)
+
+# build Marpa and execute tests
+script:
+  - (cd cpan/ && perl Makefile.PL && make && make test)
+
+sudo: false  # faster builds using containers

--- a/cpan/engine/Makefile.PL
+++ b/cpan/engine/Makefile.PL
@@ -92,6 +92,11 @@ undef &MY::postamble; # suppress warning
       );
 
     push @postamble_pieces, <<'END_OF_POSTAMBLE_PIECE';
+read_only.time-stamp:
+	date > $@
+END_OF_POSTAMBLE_PIECE
+
+    push @postamble_pieces, <<'END_OF_POSTAMBLE_PIECE';
 gnu_ac_build.time-stamp: read_only.time-stamp
 	$(RM_RF) gnu_ac_build
 	$(LIBMARPA_INSTALL) read_only gnu_ac_build


### PR DESCRIPTION
This PR provides a .travis.yml file so that Travis CI can be activated. For a successful build, this depends on PR #46. The 184f188 commit from #46 is therefore included here as well.

To activate Travis, perform the following steps:

 1. Sign up at https://travis-ci.org/ with your Github account. Grant the necessary privileges to Travis.
 2. In the list of repositories, flip the switch for the Marpa--R3 repository. No further configuration is necessary.
 3. Trigger a build, for example by merging this PR.
 4. Wait for the build to complete. In this case, that's less than 1½ mins.

You can see the build result for this commit at https://travis-ci.org/latk/p5-Marpa-R3/builds/317413142